### PR TITLE
feat: Add ObjectToBytesMapper that can replace Jackson

### DIFF
--- a/src/main/java/com/retailsvc/gcp/pubsub/ObjectToBytesMapper.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/ObjectToBytesMapper.java
@@ -1,0 +1,20 @@
+package com.retailsvc.gcp.pubsub;
+
+import java.io.IOException;
+
+/**
+ * A general-purpose mapper for objects to byte representation.
+ *
+ * @author sasjo
+ */
+@FunctionalInterface
+public interface ObjectToBytesMapper {
+  /**
+   * Convert a value to bytes.
+   *
+   * @param value a value
+   * @return the byte representation of the value.
+   * @throws IOException if failing to convert to bytes.
+   */
+  byte[] valueAsBytes(Object value) throws IOException;
+}

--- a/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientFactory.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientFactory.java
@@ -24,7 +24,7 @@ public class PubSubClientFactory {
   public static final String PROJECT_ID = "SERVICE_PROJECT_ID";
 
   private final Map<String, PubSubClient> clientCache = new ConcurrentHashMap<>();
-  private final ObjectMapper objectMapper;
+  private final ObjectToBytesMapper objectMapper;
   private final ReentrantLock lock = new ReentrantLock();
 
   public PubSubClientFactory() {
@@ -32,6 +32,10 @@ public class PubSubClientFactory {
   }
 
   public PubSubClientFactory(ObjectMapper objectMapper) {
+    this(objectMapper::writeValueAsBytes);
+  }
+
+  public PubSubClientFactory(ObjectToBytesMapper objectMapper) {
     this.objectMapper = objectMapper;
   }
 

--- a/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientImpl.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientImpl.java
@@ -1,6 +1,5 @@
 package com.retailsvc.gcp.pubsub;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.protobuf.ByteString;
@@ -30,11 +29,11 @@ class PubSubClientImpl implements PubSubClient {
   private static final int PUBLISH_TIMEOUT = 30;
 
   private final Publisher publisher;
-  private final ObjectMapper objectMapper;
+  private final ObjectToBytesMapper objectMapper;
   private final int publishTimeout;
   private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
-  public PubSubClientImpl(Supplier<Publisher> publisherFactory, ObjectMapper objectMapper) {
+  public PubSubClientImpl(Supplier<Publisher> publisherFactory, ObjectToBytesMapper objectMapper) {
     Objects.requireNonNull(publisherFactory);
     Objects.requireNonNull(objectMapper, "You need to supply an instance of ObjectMapper");
     this.objectMapper = objectMapper;
@@ -60,7 +59,7 @@ class PubSubClientImpl implements PubSubClient {
             case ByteBuffer b -> ByteString.copyFrom(b);
             case InputStream i -> ByteString.readFrom(i);
             case null -> throw new PubSubClientException("Payload object cannot be null");
-            default -> ByteString.copyFrom(objectMapper.writeValueAsBytes(payloadObject));
+            default -> ByteString.copyFrom(objectMapper.valueAsBytes(payloadObject));
           };
       var attributes = Optional.ofNullable(attributesMap).orElseGet(HashMap::new);
       publish(payload, attributes);

--- a/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientFactoryTest.java
+++ b/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientFactoryTest.java
@@ -1,7 +1,10 @@
 package com.retailsvc.gcp.pubsub;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,5 +24,12 @@ class PubSubClientFactoryTest {
     PubSubClient client2 = factory.create("test");
 
     assertThat(client1).isSameAs(client2);
+  }
+
+  @Test
+  void customMapper() throws IOException {
+    ObjectToBytesMapper mapper = mock();
+    var custom = assertDoesNotThrow(() -> new PubSubClientFactory(mapper));
+    assertDoesNotThrow(() -> custom.create("test"));
   }
 }

--- a/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientImplTest.java
+++ b/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientImplTest.java
@@ -126,7 +126,7 @@ class PubSubClientImplTest {
   }
 
   private PubSubClientImpl createClient() {
-    return new PubSubClientImpl(() -> mockPublisher, objectMapper);
+    return new PubSubClientImpl(() -> mockPublisher, objectMapper::writeValueAsBytes);
   }
 
   private record TestPayload(String key) {}


### PR DESCRIPTION
Introduce intermediate object mapper function to allow clients to use PubSub without Jackson binding library.