### PR TITLE
feat: Add PooledPublisherFactory

### DIFF
--- a/src/main/java/com/retailsvc/gcp/pubsub/DefaultPublisherFactory.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/DefaultPublisherFactory.java
@@ -1,0 +1,17 @@
+package com.retailsvc.gcp.pubsub;
+
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.pubsub.v1.TopicName;
+
+/**
+ * A default publisher factory that uses the PubSub default settings.
+ *
+ * @author sasjo
+ */
+public class DefaultPublisherFactory implements PublisherFactory {
+
+  @Override
+  public Publisher.Builder newBuilder(TopicName topic) {
+    return Publisher.newBuilder(topic);
+  }
+}

--- a/src/main/java/com/retailsvc/gcp/pubsub/PooledPublisherFactory.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/PooledPublisherFactory.java
@@ -1,0 +1,71 @@
+package com.retailsvc.gcp.pubsub;
+
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.grpc.ChannelPoolSettings;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.pubsub.v1.TopicName;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * A factory to create a publisher backed by a pool of gRPC channels. A pooled publisher can handle
+ * higher concurrent publish RPCs on the API. The created pool is dynamic and will scale in and out
+ * depending on load.
+ *
+ * <p>The publisher is configured to use virtual threads to reduce memory footprint.
+ *
+ * @param maxChannelCount the max number of gRPC channels in the pool
+ * @param maxRpcsPerChannel the max number of concurrent RPCs allowed on one channel
+ * @author sasjo
+ */
+public record PooledPublisherFactory(int maxChannelCount, int maxRpcsPerChannel)
+    implements PublisherFactory {
+
+  /** Default max pool size. Sized to support 500 concurrent API calls. */
+  private static final int DEFAULT_POOL_MAX_SIZE = 10;
+
+  /** Default pool max RPCs per channel. */
+  private static final int DEFAULT_POOL_MAX_RPC_PER_CHANNEL = 50;
+
+  /**
+   * Create a default pooled publisher that can support up to 500 concurrent requests.
+   *
+   * @return a publisher pool that can support up to 500 concurrent requests.
+   */
+  public static PooledPublisherFactory defaultPool() {
+    return new PooledPublisherFactory(DEFAULT_POOL_MAX_SIZE, DEFAULT_POOL_MAX_RPC_PER_CHANNEL);
+  }
+
+  @Override
+  public Publisher.Builder newBuilder(TopicName topic) {
+    return Publisher.newBuilder(topic)
+        .setChannelProvider(
+            InstantiatingGrpcChannelProvider.newBuilder()
+                .setChannelPoolSettings(
+                    ChannelPoolSettings.builder()
+                        .setMaxRpcsPerChannel(maxRpcsPerChannel)
+                        .setMinRpcsPerChannel(1)
+                        .setMaxChannelCount(maxChannelCount)
+                        .setPreemptiveRefreshEnabled(true)
+                        .build())
+                .setExecutor(
+                    Executors.newThreadPerTaskExecutor(
+                        Thread.ofVirtual().name("pubsub-channel-", 0).factory()))
+                .build())
+        .setExecutorProvider(new VirtualExecutorProvider());
+  }
+
+  private static class VirtualExecutorProvider implements ExecutorProvider {
+    @Override
+    public boolean shouldAutoClose() {
+      return true;
+    }
+
+    @Override
+    public ScheduledExecutorService getExecutor() {
+      return Executors.newScheduledThreadPool(
+          1, Thread.ofVirtual().name("pubsub-executor-", 0).factory());
+    }
+  }
+}

--- a/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientFactory.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientFactory.java
@@ -29,25 +29,26 @@ public class PubSubClientFactory {
   private final PublisherFactory publisherFactory;
 
   public PubSubClientFactory() {
-    this(new ObjectMapper(), new DefaultPublisherFactory());
+    this(new ObjectMapper());
+  }
+
+  public PubSubClientFactory(ObjectMapper objectMapper) {
+    this(objectMapper::writeValueAsBytes);
+  }
+
+  public PubSubClientFactory(ObjectToBytesMapper objectMapper) {
+    this(objectMapper, new DefaultPublisherFactory());
   }
 
   public PubSubClientFactory(PublisherFactory publisherFactory) {
     this(new ObjectMapper(), publisherFactory);
   }
 
-  public PubSubClientFactory(ObjectMapper objectMapper) {
-<<<<<<< HEAD
-    this(objectMapper::writeValueAsBytes);
-  }
-
-  public PubSubClientFactory(ObjectToBytesMapper objectMapper) {
-=======
-    this(objectMapper, new DefaultPublisherFactory());
-  }
-
   public PubSubClientFactory(ObjectMapper objectMapper, PublisherFactory publisherFactory) {
->>>>>>> 1695e5b (feat: Add PooledPublisherFactory)
+    this(objectMapper::writeValueAsBytes, publisherFactory);
+  }
+
+  public PubSubClientFactory(ObjectToBytesMapper objectMapper, PublisherFactory publisherFactory) {
     this.objectMapper = objectMapper;
     this.publisherFactory = publisherFactory;
   }

--- a/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientFactory.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientFactory.java
@@ -26,17 +26,30 @@ public class PubSubClientFactory {
   private final Map<String, PubSubClient> clientCache = new ConcurrentHashMap<>();
   private final ObjectToBytesMapper objectMapper;
   private final ReentrantLock lock = new ReentrantLock();
+  private final PublisherFactory publisherFactory;
 
   public PubSubClientFactory() {
-    this(new ObjectMapper());
+    this(new ObjectMapper(), new DefaultPublisherFactory());
+  }
+
+  public PubSubClientFactory(PublisherFactory publisherFactory) {
+    this(new ObjectMapper(), publisherFactory);
   }
 
   public PubSubClientFactory(ObjectMapper objectMapper) {
+<<<<<<< HEAD
     this(objectMapper::writeValueAsBytes);
   }
 
   public PubSubClientFactory(ObjectToBytesMapper objectMapper) {
+=======
+    this(objectMapper, new DefaultPublisherFactory());
+  }
+
+  public PubSubClientFactory(ObjectMapper objectMapper, PublisherFactory publisherFactory) {
+>>>>>>> 1695e5b (feat: Add PooledPublisherFactory)
     this.objectMapper = objectMapper;
+    this.publisherFactory = publisherFactory;
   }
 
   /**
@@ -67,7 +80,7 @@ public class PubSubClientFactory {
   private Supplier<Publisher> publisherFactory(String topic) {
     return () -> {
       try {
-        var builder = Publisher.newBuilder(createTopic(topic));
+        var builder = publisherFactory.newBuilder(createTopic(topic));
         emulatorHost().ifPresent(ignored -> EmulatorRedirect.redirect(builder));
         return builder.build();
       } catch (IOException e) {

--- a/src/main/java/com/retailsvc/gcp/pubsub/PublisherFactory.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/PublisherFactory.java
@@ -1,0 +1,21 @@
+package com.retailsvc.gcp.pubsub;
+
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.pubsub.v1.TopicName;
+
+/**
+ * Factory to create a Pub/Sub publisher for a topic.
+ *
+ * @author sasjo
+ */
+@FunctionalInterface
+public interface PublisherFactory {
+
+  /**
+   * Create a new publisher.
+   *
+   * @param topic the topic name
+   * @return the created publisher.
+   */
+  Publisher.Builder newBuilder(TopicName topic);
+}

--- a/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientFactoryTest.java
+++ b/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientFactoryTest.java
@@ -3,6 +3,8 @@ package com.retailsvc.gcp.pubsub;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,5 +33,13 @@ class PubSubClientFactoryTest {
     ObjectToBytesMapper mapper = mock();
     var custom = assertDoesNotThrow(() -> new PubSubClientFactory(mapper));
     assertDoesNotThrow(() -> custom.create("test"));
+  }
+
+  @Test
+  void pooledFactory() {
+    var pooled = new PubSubClientFactory(PooledPublisherFactory.defaultPool());
+    try (var client = assertDoesNotThrow(() -> pooled.create("test"))) {
+      assertNotNull(client);
+    }
   }
 }

--- a/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientFactoryTest.java
+++ b/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientFactoryTest.java
@@ -2,11 +2,9 @@ package com.retailsvc.gcp.pubsub;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.Mockito.mock;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,10 +27,12 @@ class PubSubClientFactoryTest {
   }
 
   @Test
-  void customMapper() throws IOException {
+  void customMapper() {
     ObjectToBytesMapper mapper = mock();
     var custom = assertDoesNotThrow(() -> new PubSubClientFactory(mapper));
-    assertDoesNotThrow(() -> custom.create("test"));
+    try (var client = assertDoesNotThrow(() -> custom.create("test"))) {
+      assertNotNull(client);
+    }
   }
 
   @Test


### PR DESCRIPTION
Introduce a PublisherFactory to make it easier to customize the publisher builder. The library comes with a PooledPublisherFactory that introduces a channel pool and virtual executors.