### PR TITLE
feat!: Remove built-in Jackson mapping in favor of ObjectToByteMapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <sonar.jacoco.reportPaths>${project.build.directory}/jacoco.exec, ${user.dir}/target/jacoco-it.exec</sonar.jacoco.reportPaths>
     <version.assertj>3.24.2</version.assertj>
     <version.google-cloud>26.26.0</version.google-cloud>
-    <version.jackson>2.15.3</version.jackson>
     <version.jacoco-maven-plugin>0.8.11</version.jacoco-maven-plugin>
     <version.junit-jupiter>5.10.0</version.junit-jupiter>
     <version.maven-compiler-plugin>3.11.0</version.maven-compiler-plugin>
@@ -102,12 +101,6 @@
   </dependencyManagement>
 
   <dependencies>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${version.jackson}</version>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>

--- a/src/main/java/com/retailsvc/gcp/pubsub/ObjectToBytesMapper.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/ObjectToBytesMapper.java
@@ -1,6 +1,7 @@
 package com.retailsvc.gcp.pubsub;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * A general-purpose mapper for objects to byte representation.
@@ -9,6 +10,7 @@ import java.io.IOException;
  */
 @FunctionalInterface
 public interface ObjectToBytesMapper {
+
   /**
    * Convert a value to bytes.
    *
@@ -16,5 +18,5 @@ public interface ObjectToBytesMapper {
    * @return the byte representation of the value.
    * @throws IOException if failing to convert to bytes.
    */
-  byte[] valueAsBytes(Object value) throws IOException;
+  ByteBuffer valueAsBytes(Object value) throws IOException;
 }

--- a/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientFactory.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/PubSubClientFactory.java
@@ -2,7 +2,6 @@ package com.retailsvc.gcp.pubsub;
 
 import static com.retailsvc.gcp.pubsub.EmulatorRedirect.PUBSUB_EMULATOR_HOST;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.pubsub.v1.TopicName;
 import java.io.IOException;
@@ -25,15 +24,11 @@ public class PubSubClientFactory {
 
   private final Map<String, PubSubClient> clientCache = new ConcurrentHashMap<>();
   private final ObjectToBytesMapper objectMapper;
-  private final ReentrantLock lock = new ReentrantLock();
   private final PublisherFactory publisherFactory;
+  private final ReentrantLock lock = new ReentrantLock();
 
   public PubSubClientFactory() {
-    this(new ObjectMapper());
-  }
-
-  public PubSubClientFactory(ObjectMapper objectMapper) {
-    this(objectMapper::writeValueAsBytes);
+    this((ObjectToBytesMapper) null);
   }
 
   public PubSubClientFactory(ObjectToBytesMapper objectMapper) {
@@ -41,11 +36,7 @@ public class PubSubClientFactory {
   }
 
   public PubSubClientFactory(PublisherFactory publisherFactory) {
-    this(new ObjectMapper(), publisherFactory);
-  }
-
-  public PubSubClientFactory(ObjectMapper objectMapper, PublisherFactory publisherFactory) {
-    this(objectMapper::writeValueAsBytes, publisherFactory);
+    this(null, publisherFactory);
   }
 
   public PubSubClientFactory(ObjectToBytesMapper objectMapper, PublisherFactory publisherFactory) {

--- a/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientIT.java
+++ b/src/test/java/com/retailsvc/gcp/pubsub/PubSubClientIT.java
@@ -14,6 +14,8 @@ import com.google.pubsub.v1.TopicName;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -36,7 +38,10 @@ class PubSubClientIT {
 
   @BeforeEach
   void setUp() throws Exception {
-    factory = new PubSubClientFactory();
+    factory =
+        new PubSubClientFactory(
+            (ObjectToBytesMapper)
+                v -> ByteBuffer.wrap(String.valueOf(v).getBytes(StandardCharsets.UTF_8)));
 
     emulator.start();
 


### PR DESCRIPTION
BREAKING CHANGE: Jackson ObjectMapper is no longer used as a default object conversion. To continue to map objects, implement a ObjectToBytesMapper that uses an ObjectMapper.