### PR TITLE
fix: Add initial channel count to pool factory

### DIFF
--- a/src/main/java/com/retailsvc/gcp/pubsub/PooledPublisherFactory.java
+++ b/src/main/java/com/retailsvc/gcp/pubsub/PooledPublisherFactory.java
@@ -15,12 +15,17 @@ import java.util.concurrent.ScheduledExecutorService;
  *
  * <p>The publisher is configured to use virtual threads to reduce memory footprint.
  *
+ * @param initialChannelCount the initial number of gRPC channels in the pool
  * @param maxChannelCount the max number of gRPC channels in the pool
  * @param maxRpcsPerChannel the max number of concurrent RPCs allowed on one channel
  * @author sasjo
  */
-public record PooledPublisherFactory(int maxChannelCount, int maxRpcsPerChannel)
+public record PooledPublisherFactory(
+    int initialChannelCount, int maxChannelCount, int maxRpcsPerChannel)
     implements PublisherFactory {
+
+  /** Default initial pool size. */
+  private static final int DEFAULT_POOL_INITIAL_SIZE = 2;
 
   /** Default max pool size. Sized to support 500 concurrent API calls. */
   private static final int DEFAULT_POOL_MAX_SIZE = 10;
@@ -34,7 +39,8 @@ public record PooledPublisherFactory(int maxChannelCount, int maxRpcsPerChannel)
    * @return a publisher pool that can support up to 500 concurrent requests.
    */
   public static PooledPublisherFactory defaultPool() {
-    return new PooledPublisherFactory(DEFAULT_POOL_MAX_SIZE, DEFAULT_POOL_MAX_RPC_PER_CHANNEL);
+    return new PooledPublisherFactory(
+        DEFAULT_POOL_INITIAL_SIZE, DEFAULT_POOL_MAX_SIZE, DEFAULT_POOL_MAX_RPC_PER_CHANNEL);
   }
 
   @Override
@@ -45,6 +51,7 @@ public record PooledPublisherFactory(int maxChannelCount, int maxRpcsPerChannel)
                 .setChannelPoolSettings(
                     ChannelPoolSettings.builder()
                         .setMaxRpcsPerChannel(maxRpcsPerChannel)
+                        .setInitialChannelCount(initialChannelCount)
                         .setMinRpcsPerChannel(1)
                         .setMaxChannelCount(maxChannelCount)
                         .setPreemptiveRefreshEnabled(true)


### PR DESCRIPTION
Start with 2 channels to handle initial high load.